### PR TITLE
Add --[no-]install-scylla parameter

### DIFF
--- a/src/scylla/core.clj
+++ b/src/scylla/core.clj
@@ -218,6 +218,9 @@
     :parse-fn parse-long
     :validate [pos? "must be positive"]]
 
+   [nil "--[no-]install-scylla" "Install ScyllaDB during tests"
+    :default true]
+
    [nil "--local-deb FILE" "If given, installs the local .deb file on top of the existing Scylla installation."]
 
    [nil "--local-scylla-bin FILE" (str "If provided, uploads the local file to each DB node, replacing " db/scylla-bin ". Helpful for testing development builds.")]

--- a/src/scylla/db.clj
+++ b/src/scylla/db.clj
@@ -456,7 +456,7 @@
         (enable!)
         ; Right, install
         (doto node
-          (install! test)
+          (cond-> (:install-scylla test) (install! test))
           (configure! test))
         ; And start
         (let [t1 (util/linear-time-nanos)]


### PR DESCRIPTION
This parameter required for an integration Jepsen tests into [SCT](https://github.com/scylladb/scylla-cluster-tests) pipelines. Also it can be useful for other test frameworks too.
